### PR TITLE
Added gtsam-ci dockerfiles

### DIFF
--- a/gtsam-ci/Dockerfile.ubuntu-clang
+++ b/gtsam-ci/Dockerfile.ubuntu-clang
@@ -1,0 +1,50 @@
+ARG UBUNTU_VERSION=22.04
+FROM docker.io/ubuntu:${UBUNTU_VERSION}
+
+ARG COMPILER_VERSION
+
+# Install dependencies
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirror.math.princeton.edu/pub/ubuntu/|g' /etc/apt/sources.list
+RUN apt-get -y update && apt-get -y install software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get -y update
+RUN apt-get -y install cmake \
+                        build-essential \
+                        pkg-config \
+                        libpython3-dev \
+                        python3-numpy \
+                        libicu-dev \
+                        ninja-build \
+                        libboost-all-dev
+
+# Install clang
+# (ipv4|ha).pool.sks-keyservers.net is the SKS GPG global keyserver pool
+# ipv4 avoids potential timeouts because of crappy IPv6 infrastructure
+# 15CF4D18AF4F7421 is the GPG key for the LLVM apt repository
+# This key is not in the keystore by default for Ubuntu so we need to add it.
+ARG LLVM_KEY=15CF4D18AF4F7421
+RUN gpg --keyserver keyserver.ubuntu.com --recv-key ${LLVM_KEY} || gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key ${LLVM_KEY}
+RUN gpg -a --export ${LLVM_KEY} | apt-key add -
+# LLVM (clang) 9/14 is not in Bionic's repositories so we add the official LLVM repository.
+RUN add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main"
+# LLVM (clang) 9/14 is not in 22.04 (jammy)'s repositories so we add the official LLVM repository.
+RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
+
+RUN apt-get update
+RUN apt-get install -y clang-${COMPILER_VERSION} \
+                        mold \
+                        libtbb-dev
+
+ENV CC="clang-${COMPILER_VERSION}"
+ENV CXX="clang++-${COMPILER_VERSION}"
+ENV LDFLAGS="-fuse-ld=mold"
+ENV CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
+ENV CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"
+
+# Install Eigen and Metis (needed for some tests)
+RUN apt-get update && apt-get install -y libeigen3-dev libmetis-dev
+
+WORKDIR /gtsam
+
+# Build GTSAM and run tests
+ENTRYPOINT ["bash", ".github/scripts/unix.sh", "-t"]
+

--- a/gtsam-ci/Dockerfile.ubuntu-gcc
+++ b/gtsam-ci/Dockerfile.ubuntu-gcc
@@ -1,0 +1,34 @@
+ARG UBUNTU_VERSION=22.04
+FROM docker.io/ubuntu:${UBUNTU_VERSION}
+
+ARG COMPILER_VERSION
+
+# Install dependencies
+RUN apt-get -y update && apt-get -y install software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get -y update
+RUN apt-get -y install cmake \
+                        build-essential \
+                        pkg-config \
+                        libpython3-dev \
+                        python3-numpy \
+                        libicu-dev \
+                        ninja-build \
+                        libboost-all-dev \
+                        g++-${COMPILER_VERSION} \
+                        g++-${COMPILER_VERSION}-multilib \
+                        binutils-gold \
+                        libtbb-dev
+
+ENV CC="gcc-${COMPILER_VERSION}"
+ENV CXX="g++-${COMPILER_VERSION}"
+ENV LDFLAGS="-fuse-ld=gold"
+ENV CMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold"
+ENV CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=gold"
+
+# Install Eigen and Metis (needed for some tests)
+RUN apt-get update && apt-get install -y libeigen3-dev libmetis-dev
+
+WORKDIR /gtsam
+
+# Build GTSAM and run tests
+ENTRYPOINT ["bash", ".github/scripts/unix.sh", "-t"]

--- a/gtsam-ci/README.md
+++ b/gtsam-ci/README.md
@@ -1,0 +1,8 @@
+This folder contains Dockerfiles for building containers used in the CI/CD steps of gtsam.
+
+Naming convention: `Dockerfile.{os}.{compiler}`
+
+If any changes are made to this folder/sub-folders, remember to build and push the new docker images using:
+```
+    ./build_and_push.sh
+```

--- a/gtsam-ci/build_and_push.sh
+++ b/gtsam-ci/build_and_push.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Docker Hub username
+DOCKER_USERNAME="borglab"
+DOCKER_REPOSITORY="gtsam-ci"
+
+# Define arrays for Ubuntu versions and compilers
+declare -a build_configs=( 
+  "ubuntu 22.04 gcc 9"
+  "ubuntu 22.04 clang 11"
+  "ubuntu 22.04 clang 14"
+  "ubuntu 24.04 gcc 14"
+  "ubuntu 24.04 clang 16"
+)
+
+for config in "${build_configs[@]}"; do
+  # Split the config string into variables
+  read -r os os_version compiler compiler_version <<< "$config"
+  
+  tag="${os}-${os_version}-${compiler}-${compiler_version}"
+  dockerfile_path="Dockerfile.${os}-${compiler}"
+
+  # Check if Dockerfile exists
+  if [ -f "$dockerfile_path" ]; then
+    echo "Building Docker image for $tag"
+    docker build -t "$DOCKER_USERNAME/$DOCKER_REPOSITORY:$tag" -f "$dockerfile_path" \
+      --build-arg UBUNTU_VERSION="$os_version" \
+      --build-arg COMPILER_VERSION="$compiler_version" .
+    
+    echo "Pushing Docker image $DOCKER_USERNAME/$DOCKER_REPOSITORY:$tag"
+    docker push "$DOCKER_USERNAME/$DOCKER_REPOSITORY:$tag"
+    
+    echo "Successfully built and pushed $DOCKER_USERNAME/$DOCKER_REPOSITORY:$tag"
+  else
+    echo "Warning: Dockerfile not found at $dockerfile_path, skipping..."
+  fi
+done
+ 
+echo "All Docker images processed."


### PR DESCRIPTION
Docker images built from gtsam-ci are uploaded to borglab dockerhub and used in the CI steps of GTSAM repo.