### PR TITLE
Use the ARG values directly for GTSAM CI images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/gtsam-ci/ubuntu-22.04-base.Dockerfile
+++ b/gtsam-ci/ubuntu-22.04-base.Dockerfile
@@ -1,5 +1,4 @@
-ARG UBUNTU_VERSION=22.04
-FROM docker.io/ubuntu:${UBUNTU_VERSION}
+FROM docker.io/ubuntu:22.04
 
 # Install dependencies
 RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirror.math.princeton.edu/pub/ubuntu/|g' /etc/apt/sources.list

--- a/gtsam-ci/ubuntu-22.04-clang-11.Dockerfile
+++ b/gtsam-ci/ubuntu-22.04-clang-11.Dockerfile
@@ -1,5 +1,4 @@
 FROM borglab/gtsam-ci:ubuntu-22.04-base
-ARG COMPILER_VERSION=11
 
 # Install clang
 # (ipv4|ha).pool.sks-keyservers.net is the SKS GPG global keyserver pool
@@ -15,11 +14,10 @@ RUN add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic ma
 RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
 
 RUN apt-get update
-RUN apt-get install -y clang-${COMPILER_VERSION} \
-                        mold
+RUN apt-get install -y clang-11 mold
 
-ENV CC="clang-${COMPILER_VERSION}"
-ENV CXX="clang++-${COMPILER_VERSION}"
+ENV CC="clang-11"
+ENV CXX="clang++-11"
 ENV LDFLAGS="-fuse-ld=mold"
 ENV CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
 ENV CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"

--- a/gtsam-ci/ubuntu-22.04-clang-14.Dockerfile
+++ b/gtsam-ci/ubuntu-22.04-clang-14.Dockerfile
@@ -1,5 +1,4 @@
 FROM borglab/gtsam-ci:ubuntu-22.04-base
-ARG COMPILER_VERSION=14
 
 # Install clang
 # (ipv4|ha).pool.sks-keyservers.net is the SKS GPG global keyserver pool
@@ -15,11 +14,10 @@ RUN add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic ma
 RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
 
 RUN apt-get update
-RUN apt-get install -y clang-${COMPILER_VERSION} \
-                        mold
+RUN apt-get install -y clang-14 mold
 
-ENV CC="clang-${COMPILER_VERSION}"
-ENV CXX="clang++-${COMPILER_VERSION}"
+ENV CC="clang-14"
+ENV CXX="clang++-14"
 ENV LDFLAGS="-fuse-ld=mold"
 ENV CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
 ENV CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"

--- a/gtsam-ci/ubuntu-22.04-gcc-9.Dockerfile
+++ b/gtsam-ci/ubuntu-22.04-gcc-9.Dockerfile
@@ -1,12 +1,10 @@
 FROM borglab/gtsam-ci:ubuntu-22.04-base
 ARG COMPILER_VERSION=9
 
-RUN apt-get -y install  g++-${COMPILER_VERSION} \
-                        g++-${COMPILER_VERSION}-multilib \
-                        binutils-gold
+RUN apt-get -y install  g++-9 g++-9-multilib binutils-gold
 
-ENV CC="gcc-${COMPILER_VERSION}"
-ENV CXX="g++-${COMPILER_VERSION}"
+ENV CC="gcc-9"
+ENV CXX="g++-9"
 ENV LDFLAGS="-fuse-ld=gold"
 ENV CMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold"
 ENV CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=gold"

--- a/gtsam-ci/ubuntu-24.04-base.Dockerfile
+++ b/gtsam-ci/ubuntu-24.04-base.Dockerfile
@@ -1,5 +1,4 @@
-ARG UBUNTU_VERSION=24.04
-FROM docker.io/ubuntu:${UBUNTU_VERSION}
+FROM docker.io/ubuntu:24.04
 
 # Install dependencies
 RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirror.math.princeton.edu/pub/ubuntu/|g' /etc/apt/sources.list

--- a/gtsam-ci/ubuntu-24.04-clang-16.Dockerfile
+++ b/gtsam-ci/ubuntu-24.04-clang-16.Dockerfile
@@ -1,5 +1,4 @@
 FROM borglab/gtsam-ci:ubuntu-24.04-base
-ARG COMPILER_VERSION=16
 
 # Install clang
 # (ipv4|ha).pool.sks-keyservers.net is the SKS GPG global keyserver pool
@@ -15,11 +14,10 @@ RUN add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic ma
 RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
 
 RUN apt-get update
-RUN apt-get install -y clang-${COMPILER_VERSION} \
-                        mold
+RUN apt-get install -y clang-16 mold
 
-ENV CC="clang-${COMPILER_VERSION}"
-ENV CXX="clang++-${COMPILER_VERSION}"
+ENV CC="clang-16"
+ENV CXX="clang++-16"
 ENV LDFLAGS="-fuse-ld=mold"
 ENV CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
 ENV CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"

--- a/gtsam-ci/ubuntu-24.04-gcc-14.Dockerfile
+++ b/gtsam-ci/ubuntu-24.04-gcc-14.Dockerfile
@@ -1,12 +1,9 @@
 FROM borglab/gtsam-ci:ubuntu-24.04-base
-ARG COMPILER_VERSION=14
 
-RUN apt-get -y install  g++-${COMPILER_VERSION} \
-                        g++-${COMPILER_VERSION}-multilib \
-                        binutils-gold
+RUN apt-get -y install  g++-14 g++-14-multilib binutils-gold
 
-ENV CC="gcc-${COMPILER_VERSION}"
-ENV CXX="g++-${COMPILER_VERSION}"
+ENV CC="gcc-14"
+ENV CXX="g++-14"
 ENV LDFLAGS="-fuse-ld=gold"
 ENV CMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold"
 ENV CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=gold"


### PR DESCRIPTION
Since the Dockerfiles within `gtsam-ci` are image specific, it makes sense to directly specify the value instead of using variable substitution.