### PR TITLE
[codex] Add Ubuntu 24.04 GCC 13 GTSAM CI image

### DIFF
--- a/gtsam-ci/README.md
+++ b/gtsam-ci/README.md
@@ -22,6 +22,7 @@ These extend the base images by setting up specific compilers.
 
 **Ubuntu 24.04:**
 - `ubuntu-24.04-clang-16`: Clang 16
+- `ubuntu-24.04-gcc-13`: GCC 13
 - `ubuntu-24.04-gcc-14`: GCC 14
 
 **Ubuntu 26.04:**

--- a/gtsam-ci/ubuntu-24.04-gcc-13.Dockerfile
+++ b/gtsam-ci/ubuntu-24.04-gcc-13.Dockerfile
@@ -1,0 +1,12 @@
+FROM borglab/gtsam-ci:ubuntu-24.04-base
+
+RUN apt-get -y update && apt-get -y install g++-13 g++-13-multilib binutils-gold
+
+ENV CC="gcc-13"
+ENV CXX="g++-13"
+ENV LDFLAGS="-fuse-ld=gold"
+ENV CMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold"
+ENV CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=gold"
+
+# Build GTSAM and run tests
+ENTRYPOINT ["bash", ".github/scripts/unix.sh", "-t"]


### PR DESCRIPTION
## Summary

Adds a new GTSAM CI image variant for Ubuntu 24.04 with GCC 13.

- Adds `gtsam-ci/ubuntu-24.04-gcc-13.Dockerfile`
- Uses the existing `ubuntu-24.04-base` image
- Installs `g++-13`, `g++-13-multilib`, and `binutils-gold`
- Sets `CC`, `CXX`, and gold linker environment variables consistently with the existing GCC images
- Documents the new image in `gtsam-ci/README.md`

## Validation

- `docker build -t borglab/gtsam-ci:ubuntu-24.04-gcc-13 -f gtsam-ci/ubuntu-24.04-gcc-13.Dockerfile gtsam-ci`
- `.agents/skills/gtsam-ci-image/scripts/smoke_test_image.sh ubuntu-24.04-gcc-13`

The smoke test confirmed `CC=gcc-13`, `CXX=g++-13`, GCC/G++ `13.3.0`, and CMake `3.28.3`.

Note: local Docker on this Mac reported the expected platform warning while running the linux/amd64 image on an arm64 host.